### PR TITLE
Copy not functioning with shared keys

### DIFF
--- a/ExternalModule.php
+++ b/ExternalModule.php
@@ -77,7 +77,6 @@ class ExternalModule extends AbstractExternalModule {
                 $target_key = array_key_exists( $source_key, $mapping ) ? $mapping[$source_key] : false;
                 if ( $target_key !== false ) {
                     $target_person_data[$target_key] = $value;
-                    //var_dump($value);
                     if ( !$value ) {
                         // dig into repeat_instances and pull out non-null values
                         $value = $this->digNestedData( $all_person_data, $source_key );


### PR DESCRIPTION
If the target keys and the source keys were identical between the source and target then the copy within the array would hit an error.
The recursive search through the array would also have an issue, that wouldn't resolve the search.
By separation of the source and target arrays the reads, writes, and unsetting of data no longer interferes with themselves.