### PR TITLE
support all radio layouts, map using coded values instead of choice labels

### DIFF
--- a/js/custom_data_search.js
+++ b/js/custom_data_search.js
@@ -100,9 +100,10 @@ function pasteValues(values) {
     for (let [key, value] of Object.entries(values)) {
         let $target_field = $(`input[name='${key}']`);
         if ($target_field.attr('class') == 'hiddenradio') {
-            // select radio assuming label exactly matches contents of source field
-            let $inputs = $target_field.siblings('.choicevert');
-            $inputs.find(`label:contains('${value}')`).click();
+            // collect all radio fields in all layouts
+            let $inputs = $target_field.siblings('[class*="choice"]');
+            // select radio assuming target coded value matches source coded value
+            $inputs.find(`[value='${value}']`).click();
         } else {
             // FIXME: does not honor desired date formatting
             $target_field.val(`${value}`);


### PR DESCRIPTION
Previously, radio fields would only map if the _coded value_ of the source field matched the _label value_ for the target field, this corrects that so that the coded value of the source matches the coded value of the target. I've removed the mapping from source coded value to target label entirely.

Additionally, radio fields with custom alignment are now supported.

TO TEST:

1. Navigate to the module config for any target project
    - If you do not have one, a source and target using the "Basic Demography" template will work
    - Be sure your target project has data for at least one record
1.  Map any source radio field to any corresponding target radio field
    - "Basic Demography" example:  
    ```json
    {
      "first_name": "first_name",
      "ethnicity": "ethnicity",
      "gender": "gender"
    }
    ```
1. Use the module on the appropriate instrument
1. Observe that radio fields now populate