### PR TITLE
simulate defocus of piped fields to trigger checks

### DIFF
--- a/js/custom_data_search.js
+++ b/js/custom_data_search.js
@@ -107,6 +107,7 @@ function pasteValues(values) {
         } else {
             // FIXME: does not honor desired date formatting
             $target_field.val(`${value}`);
+            $target_field.blur();
         }
     }
 }


### PR DESCRIPTION
Closes #11 (at least for validation and secondary unique checks)

This may make REDCap angry if there is more than 1 field with validation issues, if this becomes a problem it may be worthwhile to check if the `$target_field`'s `onblur` actions fire and wait for the appropriate action before continuing.