### PR TITLE
alter field GET param to pass array of fields for form

### DIFF
--- a/ExternalModule.php
+++ b/ExternalModule.php
@@ -24,9 +24,13 @@ class ExternalModule extends AbstractExternalModule {
         // only spawn search interface on specified form
         if (!in_array($instrument, (array) $this->framework->getProjectSetting('show_on_form'))) return;
 
+        $form_index = array_search($instrument, $this->framework->getProjectSetting('show_on_form'));
+        $fields = array_keys(json_decode($this->framework->getProjectSetting('mapping')[$form_index], true));
+
         $this->setJsSettings([
                 'target_pid' => $this->framework->getProjectSetting('target_pid'),
-                'ajaxpage' => $this->framework->getUrl('ajaxpage.php')
+                'ajaxpage' => $this->framework->getUrl('ajaxpage.php'),
+                'fields' => $fields
         ]);
         $this->includeJs('js/custom_data_search.js');
         DataEntry::renderSearchUtility();

--- a/js/custom_data_search.js
+++ b/js/custom_data_search.js
@@ -1,4 +1,5 @@
 $( document ).ready( function() {
+    const fieldStr = STPipe.fields.join('&field[]=');
     // hide the field selector because its options are for the target, not source project
     $("#field_select").parent().parent().hide()
     
@@ -22,7 +23,7 @@ $( document ).ready( function() {
     function enableDataSearchAutocomplete(field,arm) {
         search = null;
         search = 	$('#search_query').autocomplete({
-                        source: app_path_webroot+'DataEntry/search.php?field='+field+'&pid='+STPipe.target_pid+'&arm='+arm,
+                        source: app_path_webroot+'DataEntry/search.php?field[]='+fieldStr+'&pid='+STPipe.target_pid+'&arm='+arm,
                         minLength: 1,
                         delay: 50,
                         select: function( event, ui ) {


### PR DESCRIPTION
Also requires a small patch to `redcap_vx.y.z/DataEntry/search.php` to respect an array of fields. I can't attach the patch file so I'm putting it inline, it's mean to be run in the `redcap_v10.0.1` directory with `patch -p0 < $filename`.


```patch
--- DataEntry/search.php	2020-10-21 12:07:44.000000000 -0400
+++ DataEntry/search.php	2020-10-21 12:10:36.000000000 -0400
@@ -10,11 +10,15 @@
 if ($isAjax && isset($_GET['term']))
 {
 	// If field is passed, make sure it's valid for this project
-	if (isset($_GET['field']) && $_GET['field'] != '' && (!isset($Proj->metadata[$_GET['field']])
-			|| ($user_rights['forms'][$Proj->metadata[$_GET['field']]['form_name']] == '0' && $_GET['field'] != $Proj->table_pk)))
-	{
-		exit('[]');
-	}
+    if (isset($_GET['field'])) {
+        foreach ($_GET['field'] as $field) {
+            if ($field != '' && (!isset($Proj->metadata[$field])
+                        || ($user_rights['forms'][$Proj->metadata[$field]['form_name']] == '0' && $field != $Proj->table_pk)))
+            {
+                exit('[]');
+            }
+        }
+    }
 
 	## PERFORMANCE: Kill any currently running processes by the current user/session on THIS page
 	System::killConcurrentRequests(5);
@@ -68,8 +72,9 @@
 	}
 
 	// Search on specific field
-	if (isset($_GET['field']) && $_GET['field'] != '') {
-		$sql_field = "and field_name = '".db_escape($_GET['field'])."'";
+	if (isset($_GET['field']) && $_GET['field'] != ['']) {
+		//$sql_field = "and field_name = '".db_escape($_GET['field'])."'";
+		$sql_field = "and field_name in (" . prep_implode($_GET['field']) . ")";
 	} else {
 		// Build array of fields that user has read-only or edit access to
 		$fields = array();
```